### PR TITLE
Fixed: #39 Set/New Number param

### DIFF
--- a/functionBuilder/New-SNOWTableFunction.ps1
+++ b/functionBuilder/New-SNOWTableFunction.ps1
@@ -121,6 +121,10 @@ process {
                 'SET' {
                     $IgnoredTypes = @()
 
+                    if($Column.sys_name -eq "number" -and $Column.use_dynamic_default -eq "true"){
+                        Continue column
+                    }
+
                     if([System.Convert]::ToBoolean($Column.read_only)){
                         Write-Verbose "'$($Column.element)' param skipped. Reason: ReadOnly"
                         Continue column
@@ -145,6 +149,10 @@ process {
                     #    Write-Verbose "'$($Column.element)' param skipped. Reason: Display=false"
                     #    Continue column
                     #}
+
+                    if($Column.sys_name -eq "number" -and $Column.use_dynamic_default -eq "true"){
+                        Continue column
+                    }
 
                     if([System.Convert]::ToBoolean($Column.read_only)){
                         Write-Verbose "'$($Column.element)' param skipped. Reason: ReadOnly"

--- a/src/Public/table/New-SNOWChangeRequest.ps1
+++ b/src/Public/table/New-SNOWChangeRequest.ps1
@@ -218,9 +218,6 @@ function New-SNOWChangeRequest {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,

--- a/src/Public/table/New-SNOWIncident.ps1
+++ b/src/Public/table/New-SNOWIncident.ps1
@@ -182,9 +182,6 @@ function New-SNOWIncident {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,

--- a/src/Public/table/New-SNOWSCRequest.ps1
+++ b/src/Public/table/New-SNOWSCRequest.ps1
@@ -105,9 +105,6 @@ function New-SNOWSCRequest {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,

--- a/src/Public/table/New-SNOWSCRequestedItem.ps1
+++ b/src/Public/table/New-SNOWSCRequestedItem.ps1
@@ -130,9 +130,6 @@ function New-SNOWSCRequestedItem {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,

--- a/src/Public/table/New-SNOWSCTask.ps1
+++ b/src/Public/table/New-SNOWSCTask.ps1
@@ -86,9 +86,6 @@ function New-SNOWSCTask {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,

--- a/src/Public/table/New-SNOWTask.ps1
+++ b/src/Public/table/New-SNOWTask.ps1
@@ -86,9 +86,6 @@ function New-SNOWTask {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,

--- a/src/Public/table/Set-SNOWChangeRequest.ps1
+++ b/src/Public/table/Set-SNOWChangeRequest.ps1
@@ -218,9 +218,6 @@ function Set-SNOWChangeRequest {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,

--- a/src/Public/table/Set-SNOWIncident.ps1
+++ b/src/Public/table/Set-SNOWIncident.ps1
@@ -185,9 +185,6 @@ function Set-SNOWIncident {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,

--- a/src/Public/table/Set-SNOWSCRequest.ps1
+++ b/src/Public/table/Set-SNOWSCRequest.ps1
@@ -143,9 +143,6 @@ function Set-SNOWSCRequest {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,

--- a/src/Public/table/Set-SNOWSCRequestedItem.ps1
+++ b/src/Public/table/Set-SNOWSCRequestedItem.ps1
@@ -160,9 +160,6 @@ function Set-SNOWSCRequestedItem {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,

--- a/src/Public/table/Set-SNOWSCTask.ps1
+++ b/src/Public/table/Set-SNOWSCTask.ps1
@@ -124,9 +124,6 @@ function Set-SNOWSCTask {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,

--- a/src/Public/table/Set-SNOWTask.ps1
+++ b/src/Public/table/Set-SNOWTask.ps1
@@ -117,9 +117,6 @@ function Set-SNOWTask {
         [boolean]
         $made_sla,
         [Parameter()]
-        [string]
-        $number,
-        [Parameter()]
         [alias('opened')]
         [string]
         $opened_at,


### PR DESCRIPTION
Removed -Number parameter from New/Set table functions.
These functions rely on sys_id as the record identifier.
-Number has been incorrectly added by the function builder and is now excluded.
Removing this parameter does not break anything since it's currently defunct anyway, this is only a bug fix.